### PR TITLE
fixed SFileCompactArchive failed in win8

### DIFF
--- a/src/FileStream.cpp
+++ b/src/FileStream.cpp
@@ -465,7 +465,7 @@ static bool BaseFile_Open(
 #ifdef PLATFORM_WINDOWS
     {
         ULARGE_INTEGER FileSize;
-        DWORD dwWriteAccess = (dwStreamFlags & STREAM_FLAG_READ_ONLY) ? 0 : GENERIC_ALL;
+        DWORD dwWriteAccess = (dwStreamFlags & STREAM_FLAG_READ_ONLY) ? 0 : GENERIC_READ | GENERIC_WRITE;
         DWORD dwWriteShare = (dwStreamFlags & STREAM_FLAG_WRITE_SHARE) ? FILE_SHARE_WRITE : 0;
 
         // Open the file


### PR DESCRIPTION
this is a test case

``` C++
#define __STORMLIB_SELF__
#include "../src/StormLib.h"

int main(void)
{
    HANDLE mpq_handle = NULL;
    bool result = true;
    result = SFileCreateArchive("doodads.mpq", 0, 64, &mpq_handle);
    result = SFileAddFileEx(mpq_handle
        , "doodads.slk"
        , "doodads.slk"
        , MPQ_FILE_REPLACEEXISTING | MPQ_FILE_SINGLE_UNIT | MPQ_FILE_COMPRESS
        , MPQ_COMPRESSION_ZLIB
        , MPQ_COMPRESSION_ZLIB);
    result = SFileCompactArchive(mpq_handle, 0, false); // failed on win8
    result = SFileCloseArchive(mpq_handle);
    return 0;
}
```
