### PR TITLE
Better Windows platform detection

### DIFF
--- a/src/StormPort.h
+++ b/src/StormPort.h
@@ -36,7 +36,7 @@
 //-----------------------------------------------------------------------------
 // Defines for Windows
 
-#if !defined(PLATFORM_DEFINED) && (defined(WIN32) || defined(WIN64))
+#if !defined(PLATFORM_DEFINED) && defined(_WIN32)
 
   // In MSVC 8.0, there are some functions declared as deprecated.
   #if _MSC_VER >= 1400
@@ -52,7 +52,7 @@
   #include <wininet.h>
   #define PLATFORM_LITTLE_ENDIAN
 
-  #ifdef WIN64
+  #ifdef _WIN64
     #define PLATFORM_64BIT
   #else
     #define PLATFORM_32BIT


### PR DESCRIPTION
This PR changes `StormPort.h` to check for `_WIN32` and `_WIN64` instead of `WIN32` and `WIN64` to get better compiler coverage on Windows.

At present, MSYS2 gcc under Windows will assume the platform is Linux when you include `StormLib.h`. This is because `WIN32` and `WIN64` are user-defined macros that aren't defined by all compilers. For example, Visual Studio passes `/DWIN32` to the compiler by default.

The difference is that `_WIN32` is automatically defined by every mainstream C(++) **compiler** on Windows for both 32-bit and 64-bit builds, which means that checking for `_WIN32` is sufficient to detect the platform. You can then check `_WIN64` to narrow down a 64-bit target. [This page details the macros defined by mainstream compilers.](http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system#WindowsCygwinnonPOSIXandMinGW)

