### PR TITLE
Define PDWORD in StormPort.h

### DIFF
--- a/src/StormPort.h
+++ b/src/StormPort.h
@@ -148,6 +148,7 @@
   typedef LONG         * PLONG;
   typedef DWORD        * LPDWORD;
   typedef BYTE         * LPBYTE;
+  typedef DWORD        * PDWORD;
 
   #ifdef PLATFORM_32BIT
     #define _LZMA_UINT32_IS_ULONG


### PR DESCRIPTION
Fixes the following on Linux and OSX:

```
/home/travis/build/timkurvers/blizzardry/StormLib/src/SBaseFileTable.cpp: In function ‘int DefragmentFileTable(TMPQArchive*)’:
/home/travis/build/timkurvers/blizzardry/StormLib/src/SBaseFileTable.cpp:2463:5: error: ‘PDWORD’ was not declared in this scope
/home/travis/build/timkurvers/blizzardry/StormLib/src/SBaseFileTable.cpp:2463:12: error: expected ‘;’ before ‘NewIndexes’
/home/travis/build/timkurvers/blizzardry/StormLib/src/SBaseFileTable.cpp:2468:5: error: ‘NewIndexes’ was not declared in this scope
```