### PR TITLE
Added forwarding declaration for GetLastError and SetLastError in Windows builds

### DIFF
--- a/src/StormLib.h
+++ b/src/StormLib.h
@@ -1077,6 +1077,9 @@ int    WINAPI SCompDecompress2(void * pvOutBuffer, int * pcbOutBuffer, void * pv
 void  SetLastError(int err);
 int   GetLastError();
 
+#else
+  #pragma comment(linker, "/export:GetLastError=Kernel32.GetLastError")
+  #pragma comment(linker, "/export:SetLastError=Kernel32.SetLastError")
 #endif
 
 //-----------------------------------------------------------------------------

--- a/src/StormLib.h
+++ b/src/StormLib.h
@@ -1077,9 +1077,6 @@ int    WINAPI SCompDecompress2(void * pvOutBuffer, int * pcbOutBuffer, void * pv
 void  SetLastError(int err);
 int   GetLastError();
 
-#else
-  #pragma comment(linker, "/export:GetLastError=Kernel32.GetLastError")
-  #pragma comment(linker, "/export:SetLastError=Kernel32.SetLastError")
 #endif
 
 //-----------------------------------------------------------------------------

--- a/stormlib_dll/DllMain.c
+++ b/stormlib_dll/DllMain.c
@@ -11,6 +11,11 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+#ifdef _WIN32
+  #pragma comment(linker, "/export:GetLastError=Kernel32.GetLastError")
+  #pragma comment(linker, "/export:SetLastError=Kernel32.SetLastError")
+#endif
+
 //-----------------------------------------------------------------------------
 // DllMain
 


### PR DESCRIPTION
Hi Ladislav. 

I found that in some cases, it would be more convenient to use GetLastError and SetLastError from StormLib even on Windows. For example https://github.com/timkurvers/blizzardry/issues/51

What is your opinion on this? 
Thanks