### PR TITLE
Use regular filesystem calls instead of 64 bit versions on FreeBSD. I…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,10 @@ if(APPLE)
     set(SRC_ADDITIONAL_FILES ${TOMCRYPT_FILES} ${TOMMATH_FILES})
 endif()
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DO_LARGEFILE -Dstat64=stat -Dlstat64=lstat -Dlseek64=lseek -Doff64_t=off_t -Dfstat64=fstat -Dftruncate64=ftruncate")
+endif()
+
 if (${CMAKE_SYSTEM_NAME} STREQUAL Linux)
     message(STATUS "Using Linux port")
     option(WITH_LIBTOMCRYPT "Use system LibTomCrypt library" OFF)


### PR DESCRIPTION
…deally FileStream.cpp should be modified to work everywhere but this is a quick and harmless solution for now.