### PR TITLE
Require bzip2 on *nix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,11 @@ set(TEST_SRC_FILES
 
 add_definitions(-D_7ZIP_ST -DBZ_STRICT_ANSI)
 
+if (UNIX)
+    #Check for Bzip2
+    find_package (BZip2 REQUIRED)
+endif()
+
 if(WIN32)
     if(MSVC)
         message(STATUS "Using MSVC")


### PR DESCRIPTION
If you run CMake and then build on *nix without having bzip2-devel installed, build will fail with linker error for -lbz2. This is due to the fact that ZLIB_BZIP2_FILES is added to compile target for WIN32 only. So, bzip2 is compiled from source on Windows but not for *nix. This change fails the CMake build if bzip2 is missing.