### PR TITLE
use DWORD for get/setlasterror

### DIFF
--- a/src/FileStream.cpp
+++ b/src/FileStream.cpp
@@ -34,14 +34,14 @@
 // Local functions - platform-specific functions
 
 #ifndef PLATFORM_WINDOWS
-static int nLastError = ERROR_SUCCESS;
+static DWORD nLastError = ERROR_SUCCESS;
 
-int GetLastError()
+DWORD GetLastError()
 {
     return nLastError;
 }
 
-void SetLastError(int nError)
+void SetLastError(DWORD nError)
 {
     nLastError = nError;
 }

--- a/src/StormLib.h
+++ b/src/StormLib.h
@@ -1085,8 +1085,8 @@ int    WINAPI SCompDecompress2(void * pvOutBuffer, int * pcbOutBuffer, void * pv
 
 #ifndef PLATFORM_WINDOWS
 
-void  SetLastError(int err);
-int   GetLastError();
+void  SetLastError(DWORD err);
+DWORD   GetLastError();
 
 #endif
 


### PR DESCRIPTION
correct type for GetLastError and SetLastError is DWORD (would cause warnings because of unsigned/signed conversion if using a DWORD variable to store the result)