### PR TITLE
SFileSetFilePointer error when new pointer is <0

### DIFF
--- a/src/SFileReadFile.cpp
+++ b/src/SFileReadFile.cpp
@@ -867,8 +867,8 @@ DWORD WINAPI SFileSetFilePointer(HANDLE hFile, LONG lFilePos, LONG * plFilePosHi
     // If moving backward, don't allow the new position go negative
     if((LONGLONG)DeltaPos < 0)
     {
-        if(NewPosition > FileSize)
-            NewPosition = 0;
+        if(NewPosition > FileSize) // Position is negative
+            return SFILE_INVALID_POS;
     }
 
     // If moving forward, don't allow the new position go past the end of the file


### PR DESCRIPTION
The standard behaviour for fseek / SetFilePointer when the new pointed value would be negative is to not move the pointer and return an error.
See : https://msdn.microsoft.com/en-us/library/windows/desktop/aa365541(v=vs.85).aspx `If a new file pointer is a negative value, the function fails, the file pointer is not moved, and the code returned by GetLastError is ERROR_NEGATIVE_SEEK.`