### PR TITLE
Stormlib no auto link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(StormLib)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 
 set(LIBRARY_NAME storm)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,7 @@ endif()
 add_library(${LIBRARY_NAME} ${LIB_TYPE} ${SRC_FILES} ${SRC_ADDITIONAL_FILES})
 
 target_link_libraries(${LIBRARY_NAME} ${LINK_LIBS})
-target_compile_definitions(${LIBRARY_NAME} PUBLIC) #CMake should take care of the linking
+target_compile_definitions(${LIBRARY_NAME} INTERFACE STORMLIB_NO_AUTO_LINK) #CMake will take care of the linking
 target_include_directories(${LIBRARY_NAME} PUBLIC src/)
 set_target_properties(${LIBRARY_NAME} PROPERTIES PUBLIC_HEADER "src/StormLib.h;src/StormPort.h")
 if(BUILD_SHARED_LIBS)

--- a/src/StormLib.h
+++ b/src/StormLib.h
@@ -99,8 +99,11 @@ extern "C" {
 //  Z - S for static-linked CRT library, D for multithreaded DLL CRT library
 //
 
-#if defined(_MSC_VER) && !defined(__STORMLIB_SELF__)
-  
+#if defined(__STORMLIB_SELF__) && !defined(STORMLIB_NO_AUTO_LINK)
+#define STORMLIB_NO_AUTO_LINK // Define this if you don't want to link using pragmas when using msvc
+#endif
+
+#if defined(_MSC_VER) && !defined(STORMLIB_NO_AUTO_LINK)
   #ifdef _DEBUG                                 // DEBUG VERSIONS
     #ifndef _UNICODE                            
       #ifdef _DLL                               


### PR DESCRIPTION
Since #90 seemed to be too much changes at once, I'll try to clean up the CMakelists.txt bit by bit to provide new features and easier update/selection of dependencies.

For now, I just bumped the cmake required version to 2.8.12 since the CMakelists.txt already uses target_* commands, and added a new defined `STORMLIB_NO_AUTO_LINK`.
This lets the user chose how to link the library by defining `STORMLIB_NO_AUTO_LINK` before inclusion.
In terms of feature, it is exactly the same as `__STORMLIB_SELF__`, but I added a new define in case `__STORMLIB_SELF__` needs to be used for anything else in the future.

I also added `STORMLIB_NO_AUTO_LINK` to the cmake `INTERFACE` property so that someone can link directly against it using CMake.
Note that I did note make it `PUBLIC` so that it is not defined when building the library alone, and this will not cause problems such as the one mentionned by @namreeb on https://github.com/ladislav-zezula/StormLib/commit/64e610177730715c2b45c12186767316e40cc6c5

If you think this new define is redundant we can put the `__STORMLIB_SELF__` define back, @namreeb's issue can be fixed by using 
`target_compile_definitions(${LIBRARY_NAME} INTERFACE __STORMLIB_SELF__)`
instead of 
`target_compile_definitions(${LIBRARY_NAME} PUBLIC __STORMLIB_SELF__)`
since it will define it only for targets that link stormlib and not when building it.

In a future PR I will try to move all dependencies to a 3rdparty folder, so that it is easier to update or exclude for the users.