### PR TITLE
Set SFileSetFilePointer error when new pointer < 0

### DIFF
--- a/src/SFileReadFile.cpp
+++ b/src/SFileReadFile.cpp
@@ -868,6 +868,7 @@ DWORD WINAPI SFileSetFilePointer(HANDLE hFile, LONG lFilePos, LONG * plFilePosHi
     if((LONGLONG)DeltaPos < 0)
     {
         if(NewPosition > FileSize) // Position is negative
+            SetLastError(ERROR_NEGATIVE_SEEK);
             return SFILE_INVALID_POS;
     }
 

--- a/src/StormPort.h
+++ b/src/StormPort.h
@@ -211,6 +211,7 @@
   #define ERROR_NOT_ENOUGH_MEMORY        ENOMEM
   #define ERROR_NOT_SUPPORTED            ENOTSUP
   #define ERROR_INVALID_PARAMETER        EINVAL
+  #define ERROR_NEGATIVE_SEEK            EINVAL
   #define ERROR_DISK_FULL                ENOSPC
   #define ERROR_ALREADY_EXISTS           EEXIST
   #define ERROR_INSUFFICIENT_BUFFER      ENOBUFS


### PR DESCRIPTION
This addresses an apparent oversight in the following commit:

- 951f416398b3aa0b32969b4a391a3103443ad99e

An error is not actually set, even though the return value now correctly
indicates failure.  Per the documentation for [`SetFilerPointer ()`][1],
this should be set to `ERROR_NEGATIVE_SEEK` on Windows.  On Mac/Linux,
this would be `EINVAL` as per the documentation for [`fseek ()`][2].

[1]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365541(v=vs.85).aspx
[2]: http://pubs.opengroup.org/onlinepubs/9699919799/functions/fseek.html