### PR TITLE
Add brackets in SFileSetFilePointer when pointer < 0

### DIFF
--- a/src/SFileReadFile.cpp
+++ b/src/SFileReadFile.cpp
@@ -868,8 +868,10 @@ DWORD WINAPI SFileSetFilePointer(HANDLE hFile, LONG lFilePos, LONG * plFilePosHi
     if((LONGLONG)DeltaPos < 0)
     {
         if(NewPosition > FileSize) // Position is negative
+        {
             SetLastError(ERROR_NEGATIVE_SEEK);
             return SFILE_INVALID_POS;
+        }
     }
 
     // If moving forward, don't allow the new position go past the end of the file


### PR DESCRIPTION
This addresses a bug introduced in:

- fe652fe4a6e02041194a0f1b29a0086bd99fb14d

Brackets were not properly included, causing `SFILE_INVALID_POS` to be
returned whenever `DeltaPos` was less than zero, instead of only when
the resulting position was negative.

I apologize for not noticing this earlier.