### PR TITLE
Support for mpq not being the last part of a file

### DIFF
--- a/src/SFileVerify.cpp
+++ b/src/SFileVerify.cpp
@@ -767,7 +767,7 @@ bool QueryMpqSignatureInfo(
 
         // Check the signature header "NGIS"
         if(pSI->Signature[0] != 'N' || pSI->Signature[1] != 'G' || pSI->Signature[2] != 'I' || pSI->Signature[3] != 'S')
-            return false;
+            return true; //Not a valid signature, but another filetype could've been appended so not always an error.
 
         pSI->SignatureTypes |= SIGNATURE_TYPE_STRONG;
         return true;


### PR DESCRIPTION
This might not be a common thing, but having multiple file types appended onto a file is perfectly fine with Warcraft3 and the World editor(although saving the map loses all of that). A test case would be getting any .exe, appending an .w3m to it and then appending some other file type like .zip(I used the cat command for that). When the map is opened it works just fine, but trying to get its signature info from StormLib fails.