### PR TITLE
StormPort: Suppress `min/max` macros from windows

### DIFF
--- a/src/StormPort.h
+++ b/src/StormPort.h
@@ -48,7 +48,11 @@
   #include <assert.h>
   #include <ctype.h>
   #include <stdio.h>
+
+  // Suppress definitions of `min` and `max` macros by <windows.h>:
+  #define NOMINMAX 1
   #include <windows.h>
+
   #include <wininet.h>
   #define PLATFORM_LITTLE_ENDIAN
 


### PR DESCRIPTION
This makes StormLib usable with C++ stdlib (e.g. the <algorithm> header which defines std::min/max)