### PR TITLE
change ERROR_NEGATIVE_SEEK to ESPIPE

### DIFF
--- a/src/StormPort.h
+++ b/src/StormPort.h
@@ -246,7 +246,7 @@
   #define ERROR_NOT_ENOUGH_MEMORY        ENOMEM
   #define ERROR_NOT_SUPPORTED            ENOTSUP
   #define ERROR_INVALID_PARAMETER        EINVAL
-  #define ERROR_NEGATIVE_SEEK            EINVAL
+  #define ERROR_NEGATIVE_SEEK            ESPIPE
   #define ERROR_DISK_FULL                ENOSPC
   #define ERROR_ALREADY_EXISTS           EEXIST
   #define ERROR_INSUFFICIENT_BUFFER      ENOBUFS


### PR DESCRIPTION
looks better if we want to differ INVALID_PARAMETER and incorrect seek I think?

maybe this is wrong