### PR TITLE
removed unnecessary bitmasking

### DIFF
--- a/src/pklib/implode.c
+++ b/src/pklib/implode.c
@@ -663,7 +663,7 @@ unsigned int PKEXPORT implode(
         for(nCount2 = 0; nCount2 < (1 << ExLenBits[i]); nCount2++)
         {
             pWork->nChBits[nCount]  = (unsigned char)(ExLenBits[i] + LenBits[i] + 1);
-            pWork->nChCodes[nCount] = (unsigned short)((nCount2 << (LenBits[i] + 1)) | ((LenCode[i] & 0xFFFF00FF) * 2) | 1);
+            pWork->nChCodes[nCount] = (unsigned short)((nCount2 << (LenBits[i] + 1)) | (LenCode[i] * 2) | 1);
             nCount++;
         }
     }


### PR DESCRIPTION
LenCode is an array of 8 bit chars, masking it's values with a 32 bit integer is unnecessary.