### PR TITLE
Ensure ReleaseUD for Win32 uses Unicode

### DIFF
--- a/StormLib_vs19.vcxproj
+++ b/StormLib_vs19.vcxproj
@@ -120,7 +120,7 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseUD|Win32'" Label="Configuration">
-    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseUD|x64'" Label="Configuration">
     <CharacterSet>Unicode</CharacterSet>


### PR DESCRIPTION
Noticed this inconsistency in the solution configuration for ReleaseUD for Win32, where the character set was not set.