### PR TITLE
FileStream: Ensure file handle invalidation on error

### DIFF
--- a/src/FileStream.cpp
+++ b/src/FileStream.cpp
@@ -113,6 +113,7 @@ static bool BaseFile_Create(TFileStream * pStream)
         if(handle == -1)
         {
             nLastError = errno;
+            pStream->Base.File.hFile = INVALID_HANDLE_VALUE;
             return false;
         }
 
@@ -165,6 +166,7 @@ static bool BaseFile_Open(TFileStream * pStream, const TCHAR * szFileName, DWORD
         if(handle == -1)
         {
             nLastError = errno;
+            pStream->Base.File.hFile = INVALID_HANDLE_VALUE;
             return false;
         }
 
@@ -173,6 +175,7 @@ static bool BaseFile_Open(TFileStream * pStream, const TCHAR * szFileName, DWORD
         {
             nLastError = errno;
             close(handle);
+            pStream->Base.File.hFile = INVALID_HANDLE_VALUE;
             return false;
         }
 


### PR DESCRIPTION
If the file fails to open, the file handle must be invalidated.

/cc @AJenbo