### PR TITLE
Make nLastError thread-local

### DIFF
--- a/src/FileStream.cpp
+++ b/src/FileStream.cpp
@@ -34,7 +34,7 @@
 // Local functions - platform-specific functions
 
 #ifndef STORMLIB_WINDOWS
-static DWORD nLastError = ERROR_SUCCESS;
+static thread_local DWORD nLastError = ERROR_SUCCESS;
 
 DWORD GetLastError()
 {


### PR DESCRIPTION
Before this fix, `Get/SetLastError` on non-Windows behaved incorrectly when used from multiple threads.