### PR TITLE
Change output name of Windows cmake to StormLib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,9 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
 endif()
 
 add_library(${LIBRARY_NAME} ${LIB_TYPE} ${SRC_FILES} ${SRC_ADDITIONAL_FILES} ${STORM_DEF_FILES})
+if(WIN32)
+set_target_properties(${LIBRARY_NAME} PROPERTIES OUTPUT_NAME "StormLib")
+endif()
 
 target_link_libraries(${LIBRARY_NAME} ${LINK_LIBS})
 target_compile_definitions(${LIBRARY_NAME} INTERFACE STORMLIB_NO_AUTO_LINK) #CMake will take care of the linking


### PR DESCRIPTION
This will change the .lib/.dll output file name to `StormLib` instead `storm` when build with cmake for Windows.

BTW, using `RUNTIME_OUTPUT_NAME` instead of `OUTPUT_NAME` will only change the .dll file name (leave the .lib file name untouched).  I could change the PR if that is more appropriate.