### PR TITLE
Add `STORM_USE_BUNDLED_LIBRARIES` option that defaults to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY_NAME storm)
 include(CMakeDependentOption)
 
 option(BUILD_SHARED_LIBS "Compile shared libraries" OFF)
+option(STORM_USE_BUNDLED_LIBRARIES "Use bundled dependencies instead of system libraries." OFF)
 option(STORM_SKIP_INSTALL "Skip installing files" OFF)
 option(STORM_BUILD_TESTS
     "Compile StormLib test application" OFF
@@ -279,9 +280,11 @@ set(TEST_SRC_FILES
 
 add_definitions(-D_7ZIP_ST -DBZ_STRICT_ANSI)
 
-if(WIN32)
+if(WIN32 OR STORM_USE_BUNDLED_LIBRARIES)
     set(SRC_ADDITIONAL_FILES ${ZLIB_BZIP2_FILES} ${TOMCRYPT_FILES} ${TOMMATH_FILES})
-    set(LINK_LIBS wininet)
+    if(WIN32)
+        set(LINK_LIBS wininet)
+    endif()
 else()
     find_package(ZLIB REQUIRED)
     find_package(BZip2 REQUIRED)


### PR DESCRIPTION
Hello,

I'm in the process of writing Rust bindings for [namigator](https://github.com/namreeb/namigator) and I want to statically link as much as possible in order to guarantee reproducibility and require as few external dependencies as possible.

Adding this option means that I won't have to manually include and set up zlib and bzip2.

Let me know if you want any changes or want it done another way.