### PR TITLE
Add `STORM_USE_BUNDLED_LIBRARIES` option that defaults to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ include(CMakeDependentOption)
 
 option(BUILD_SHARED_LIBS "Compile shared libraries" OFF)
 option(STORM_SKIP_INSTALL "Skip installing files" OFF)
+option(STORM_USE_BUNDLED_LIBRARIES
+    "Force use of bundled dependencies instead of system libraries."
+    OFF
+)
 option(STORM_BUILD_TESTS
     "Compile StormLib test application" OFF
 #   "BUILD_TESTING" OFF # Stay coherent with CTest variables
@@ -286,7 +290,7 @@ add_definitions(-D_7ZIP_ST -DBZ_STRICT_ANSI)
 set(LINK_LIBS)
 
 find_package(ZLIB)
-if (ZLIB_FOUND)
+if (ZLIB_FOUND AND NOT STORM_USE_BUNDLED_LIBRARIES)
 	set(LINK_LIBS ${LINK_LIBS} ZLIB::ZLIB)
     add_definitions(-D__SYS_ZLIB)
 else()
@@ -294,7 +298,7 @@ else()
 endif()
 
 find_package(BZip2)
-if (BZIP2_FOUND)
+if (BZIP2_FOUND AND NOT STORM_USE_BUNDLED_LIBRARIES)
 	set(LINK_LIBS ${LINK_LIBS} BZip2::BZip2)
     add_definitions(-D__SYS_BZLIB)
 else()


### PR DESCRIPTION
Reopen of https://github.com/ladislav-zezula/StormLib/pull/263 with updated `master`.

From previous PR:

Hello,

I'm in the process of writing Rust bindings for [namigator](https://github.com/namreeb/namigator) and I want to statically link as much as possible in order to guarantee reproducibility and require as few external dependencies as possible.

Adding this option means that I won't have to manually include and set up zlib and bzip2.

Let me know if you want any changes or want it done another way.

Sorry about the PR spam. :/