### PR TITLE
Add enums for sizes of different data structures in `pklib.h`.

### DIFF
--- a/src/pklib/pklib.h
+++ b/src/pklib/pklib.h
@@ -27,6 +27,30 @@
 #define CMP_IMPLODE_DICT_SIZE2   2048       // Dictionary size of 2048
 #define CMP_IMPLODE_DICT_SIZE3   4096       // Dictionary size of 4096
 
+enum CommonSizes {
+    OUT_BUFF_SIZE = 0x802
+};
+
+enum LUTSizes {
+    DIST_SIZES = 0x40,
+    CH_BITS_ASC_SIZE = 0x100,
+    LENS_SIZES = 0x10,
+};
+
+enum ImplodeSizes {
+    OFFSS_SIZE2 = 0x204,
+    LITERALS_COUNT = 0x306,
+    HASHTABLE_SIZE = 0x900,
+    BUFF_SIZE = 0x2204,
+};
+
+enum ExplodeSizes{
+    IN_BUFF_SIZE = 0x800,
+    CODES_SIZE = 0x100,
+    OFFSS_SIZE = 0x100,
+    OFFSS_SIZE1 = 0x80,
+};
+
 //-----------------------------------------------------------------------------
 // Define calling convention
 
@@ -51,25 +75,25 @@ typedef struct
     unsigned int   dsize_mask;              // 0010: Bit mask for dictionary. 0x0F = 0x400, 0x1F = 0x800, 0x3F = 0x1000
     unsigned int   ctype;                   // 0014: Compression type (CMP_ASCII or CMP_BINARY)
     unsigned int   dsize_bytes;             // 0018: Dictionary size in bytes
-    unsigned char  dist_bits[0x40];         // 001C: Distance bits
-    unsigned char  dist_codes[0x40];        // 005C: Distance codes
-    unsigned char  nChBits[0x306];          // 009C: Table of literal bit lengths to be put to the output stream
-    unsigned short nChCodes[0x306];         // 03A2: Table of literal codes to be put to the output stream
+    unsigned char  dist_bits[DIST_SIZES];   // 001C: Distance bits
+    unsigned char  dist_codes[DIST_SIZES];  // 005C: Distance codes
+    unsigned char  nChBits[LITERALS_COUNT]; // 009C: Table of literal bit lengths to be put to the output stream
+    unsigned short nChCodes[LITERALS_COUNT];// 03A2: Table of literal codes to be put to the output stream
     unsigned short offs09AE;                // 09AE:
 
     void         * param;                   // 09B0: User parameter
     unsigned int (*read_buf)(char *buf, unsigned int *size, void *param);  // 9B4
     void         (*write_buf)(char *buf, unsigned int *size, void *param); // 9B8
 
-    unsigned short offs09BC[0x204];         // 09BC:
+    unsigned short offs09BC[OFFSS_SIZE2];   // 09BC:
     unsigned long  offs0DC4;                // 0DC4:
-    unsigned short phash_to_index[0x900];   // 0DC8: Array of indexes (one for each PAIR_HASH) to the "pair_hash_offsets" table
+    unsigned short phash_to_index[HASHTABLE_SIZE];  // 0DC8: Array of indexes (one for each PAIR_HASH) to the "pair_hash_offsets" table
     unsigned short phash_to_index_end;      // 1FC8: End marker for "phash_to_index" table
-    char           out_buff[0x802];         // 1FCA: Compressed data
-    unsigned char  work_buff[0x2204];       // 27CC: Work buffer
+    char           out_buff[OUT_BUFF_SIZE]; // 1FCA: Compressed data
+    unsigned char  work_buff[BUFF_SIZE];     // 27CC: Work buffer
                                             //  + DICT_OFFSET  => Dictionary
                                             //  + UNCMP_OFFSET => Uncompressed data
-    unsigned short phash_offs[0x2204];      // 49D0: Table of offsets for each PAIR_HASH
+    unsigned short phash_offs[BUFF_SIZE];    // 49D0: Table of offsets for each PAIR_HASH
 } TCmpStruct;
 
 #define CMP_BUFFER_SIZE  sizeof(TCmpStruct) // Size of compression structure.
@@ -96,18 +120,18 @@ typedef struct
                                             //       0x0000 - 0x0FFF: Previous uncompressed data, kept for repetitions
                                             //       0x1000 - 0x1FFF: Currently decompressed data
                                             //       0x2000 - 0x2203: Reserve space for the longest possible repetition
-    unsigned char in_buff[0x800];           // 2234: Buffer for data to be decompressed
-    unsigned char DistPosCodes[0x100];      // 2A34: Table of distance position codes
-    unsigned char LengthCodes[0x100];       // 2B34: Table of length codes
-    unsigned char offs2C34[0x100];          // 2C34: Buffer for
-    unsigned char offs2D34[0x100];          // 2D34: Buffer for
-    unsigned char offs2E34[0x80];           // 2E34: Buffer for
-    unsigned char offs2EB4[0x100];          // 2EB4: Buffer for
-    unsigned char ChBitsAsc[0x100];         // 2FB4: Buffer for
-    unsigned char DistBits[0x40];           // 30B4: Numbers of bytes to skip copied block length
-    unsigned char LenBits[0x10];            // 30F4: Numbers of bits for skip copied block length
-    unsigned char ExLenBits[0x10];          // 3104: Number of valid bits for copied block
-    unsigned short LenBase[0x10];           // 3114: Buffer for
+    unsigned char in_buff[IN_BUFF_SIZE];           // 2234: Buffer for data to be decompressed
+    unsigned char DistPosCodes[CODES_SIZE];      // 2A34: Table of distance position codes
+    unsigned char LengthCodes[CODES_SIZE];       // 2B34: Table of length codes
+    unsigned char offs2C34[OFFSS_SIZE];          // 2C34: Buffer for
+    unsigned char offs2D34[OFFSS_SIZE];          // 2D34: Buffer for
+    unsigned char offs2E34[OFFSS_SIZE1];           // 2E34: Buffer for
+    unsigned char offs2EB4[OFFSS_SIZE];          // 2EB4: Buffer for
+    unsigned char ChBitsAsc[CH_BITS_ASC_SIZE];         // 2FB4: Buffer for
+    unsigned char DistBits[DIST_SIZES];           // 30B4: Numbers of bytes to skip copied block length
+    unsigned char LenBits[LENS_SIZES];            // 30F4: Numbers of bits for skip copied block length
+    unsigned char ExLenBits[LENS_SIZES];          // 3104: Number of valid bits for copied block
+    unsigned short LenBase[LENS_SIZES];           // 3114: Buffer for
 } TDcmpStruct;
 
 #define EXP_BUFFER_SIZE sizeof(TDcmpStruct) // Size of decompression structure
@@ -116,14 +140,14 @@ typedef struct
 //-----------------------------------------------------------------------------
 // Tables (in explode.c)
 
-extern const unsigned char DistBits[0x40];
-extern const unsigned char DistCode[0x40];
-extern const unsigned char ExLenBits[0x10];
-extern const unsigned short LenBase[0x10];
-extern const unsigned char LenBits[0x10];
-extern const unsigned char LenCode[0x10];
-extern const unsigned char ChBitsAsc[0x100];
-extern const unsigned short ChCodeAsc[0x100];
+extern const unsigned char DistBits[DIST_SIZES];
+extern const unsigned char DistCode[DIST_SIZES];
+extern const unsigned char ExLenBits[LENS_SIZES];
+extern const unsigned short LenBase[LENS_SIZES];
+extern const unsigned char LenBits[LENS_SIZES];
+extern const unsigned char LenCode[LENS_SIZES];
+extern const unsigned char ChBitsAsc[CH_BITS_ASC_SIZE];
+extern const unsigned short ChCodeAsc[CH_BITS_ASC_SIZE];
 
 //-----------------------------------------------------------------------------
 // Public functions


### PR DESCRIPTION
The enums document the dependences between sizes of different structures.