### PR TITLE
Add the functions to discover the sizes of compressor and decompressor structs of `pklib` in runtime.

### DIFF
--- a/src/pklib/explode.c
+++ b/src/pklib/explode.c
@@ -468,6 +468,23 @@ static unsigned int Expand(TDcmpStruct * pWork)
 
 
 //-----------------------------------------------------------------------------
+// Export exploding struct sizes
+struct ExplodeSizeConstants getExplodeSizeConstants(){
+    struct ExplodeSizeConstants res;
+    res.own_size = sizeof(struct ExplodeSizeConstants);
+    res.common = getCommonSizeConstants();
+    res.internal_struct_size = EXP_BUFFER_SIZE;
+    res.IN_BUFF_SIZE = IN_BUFF_SIZE;
+    res.CODES_SIZE = CODES_SIZE;
+    res.OFFSS_SIZE = OFFSS_SIZE;
+    res.OFFSS_SIZE1 = OFFSS_SIZE1;
+    res.CH_BITS_ASC_SIZE = CH_BITS_ASC_SIZE;
+    res.LENS_SIZES = LENS_SIZES;
+    return res;
+}
+
+
+//-----------------------------------------------------------------------------
 // Main exploding function.
 
 unsigned int PKEXPORT explode(

--- a/src/pklib/implode.c
+++ b/src/pklib/implode.c
@@ -588,6 +588,41 @@ __Exit:
 }
 
 //-----------------------------------------------------------------------------
+// Export LUTs sizes
+struct LUTSizeConstants getLUTSizeConstants(){
+    struct LUTSizeConstants res;
+    res.own_size = sizeof(struct LUTSizeConstants);
+    res.DIST_SIZES = DIST_SIZES;
+    res.CH_BITS_ASC_SIZE = CH_BITS_ASC_SIZE;
+	res.LENS_SIZES = LENS_SIZES;
+    return res;
+}
+
+//-----------------------------------------------------------------------------
+// Export common struct sizes
+struct CommonSizeConstants getCommonSizeConstants(){
+    struct CommonSizeConstants res;
+    res.own_size = sizeof(struct CommonSizeConstants);
+    res.OUT_BUFF_SIZE = OUT_BUFF_SIZE;
+    return res;
+}
+
+//-----------------------------------------------------------------------------
+// Export imploding struct sizes
+struct ImplodeSizeConstants getImplodeSizeConstants(){
+    struct ImplodeSizeConstants res;
+    res.own_size = sizeof(struct ImplodeSizeConstants);
+    res.common = getCommonSizeConstants();
+    res.internal_struct_size = CMP_BUFFER_SIZE;
+    res.OFFSS_SIZE2 = OFFSS_SIZE2;
+    res.LITERALS_COUNT = LITERALS_COUNT;
+    res.HASHTABLE_SIZE = HASHTABLE_SIZE;
+    res.BUFF_SIZE = BUFF_SIZE;
+    return res;
+}
+
+
+//-----------------------------------------------------------------------------
 // Main imploding function
 
 unsigned int PKEXPORT implode(

--- a/src/pklib/pklib.h
+++ b/src/pklib/pklib.h
@@ -63,6 +63,35 @@ enum ExplodeSizes{
 #endif
 
 //-----------------------------------------------------------------------------
+// Interface structures
+
+// Sizes of look-uptables
+struct LUTSizeConstants{
+    size_t own_size, DIST_SIZES, CH_BITS_ASC_SIZE, LENS_SIZES;
+};
+
+// Sizes needed to allocate buffer for both TCmpStruct and TDcmpStruct and access their fields in a future-proof way
+struct CommonSizeConstants{
+    size_t own_size, OUT_BUFF_SIZE;
+};
+
+// Sizes needed to allocate buffer for TCmpStruct and access its fields in a future-proof way
+struct ImplodeSizeConstants{
+    size_t own_size;
+    struct CommonSizeConstants common;
+    size_t internal_struct_size;
+    size_t OFFSS_SIZE2, LITERALS_COUNT, HASHTABLE_SIZE, BUFF_SIZE;
+};
+
+// Sizes needed to allocate buffer for TDcmpStruct and access its fields in a future-proof way
+struct ExplodeSizeConstants{
+    size_t own_size;
+    struct CommonSizeConstants common;
+    size_t internal_struct_size;
+    size_t IN_BUFF_SIZE, CODES_SIZE, OFFSS_SIZE, OFFSS_SIZE1, CH_BITS_ASC_SIZE, LENS_SIZES;
+};
+
+//-----------------------------------------------------------------------------
 // Internal structures
 
 // Compression structure
@@ -98,7 +127,6 @@ typedef struct
 
 #define CMP_BUFFER_SIZE  sizeof(TCmpStruct) // Size of compression structure.
                                             // Defined as 36312 in pkware header file
-
 
 // Decompression structure
 typedef struct
@@ -156,6 +184,11 @@ extern const unsigned short ChCodeAsc[CH_BITS_ASC_SIZE];
    extern "C" {
 #endif
 
+struct LUTSizeConstants PKEXPORT getLUTSizeConstants();
+struct CommonSizeConstants PKEXPORT getCommonSizeConstants();
+
+struct ImplodeSizeConstants PKEXPORT getImplodeSizeConstants();
+
 unsigned int PKEXPORT implode(
    unsigned int (*read_buf)(char *buf, unsigned int *size, void *param),
    void         (*write_buf)(char *buf, unsigned int *size, void *param),
@@ -164,6 +197,7 @@ unsigned int PKEXPORT implode(
    unsigned int *type,
    unsigned int *dsize);
 
+struct ExplodeSizeConstants PKEXPORT getExplodeSizeConstants();
 
 unsigned int PKEXPORT explode(
    unsigned int (*read_buf)(char *buf, unsigned  int *size, void *param),


### PR DESCRIPTION
Needed for properly splitting compressor, decompressor and LUTs into shared libs and minimizing dependency on headers (without these functions the knowledge about the sizes have to be in headers). Needed for calling the libs from other languages (`Python`). If the sizes ever changed, there would be no need to make changes in Python code, since we can import the introspection functions first, then generate the `ctypes.Struct`s for compressors/decompressors, and then use them. This way Python package becomes decoupled from the shared libs versions to some extent.