### PR TITLE
Manipulate MPQs From Memory

### DIFF
--- a/src/SFileListFile.cpp
+++ b/src/SFileListFile.cpp
@@ -558,6 +558,25 @@ static DWORD SFileAddArbitraryListFile(
     return (pCache != NULL) ? ERROR_SUCCESS : ERROR_FILE_CORRUPT;
 }
 
+static int SFileAddArbitraryListFile(
+    TMPQArchive * ha,
+    const char ** listFileEntries,
+    DWORD dwEntryCount)
+{
+    if(listFileEntries != NULL && dwEntryCount > 0)
+    {
+        // Get the next line
+        for (DWORD dwListFileNum=0; dwListFileNum<dwEntryCount; dwListFileNum++)
+        {
+            const char* listFileEntry = listFileEntries[dwListFileNum];
+            if ( listFileEntry != NULL )
+                SListFileCreateNodeForAllLocales(ha, listFileEntry);
+        }
+    }
+
+    return (listFileEntries != NULL && dwEntryCount > 0) ? ERROR_SUCCESS : ERROR_INVALID_PARAMETER;
+}
+
 static DWORD SFileAddInternalListFile(
     TMPQArchive * ha,
     HANDLE hMpq)
@@ -599,6 +618,32 @@ static DWORD SFileAddInternalListFile(
     }
 
     // Return the result of the operation
+    return dwErrCode;
+}
+
+DWORD WINAPI SFileAddListFileEntries(HANDLE hMpq, const char ** listFileEntries, DWORD dwEntryCount)
+{
+    TMPQArchive * ha = (TMPQArchive *)hMpq;
+    DWORD dwErrCode = ERROR_SUCCESS;
+
+    // Add the listfile for each MPQ in the patch chain
+    while(ha != NULL)
+    {
+        if(listFileEntries != NULL && dwEntryCount > 0)
+            dwErrCode = SFileAddArbitraryListFile(ha, listFileEntries, dwEntryCount);
+        else
+            dwErrCode = SFileAddInternalListFile(ha, hMpq);
+
+        // Also, add three special files to the listfile:
+        // (listfile) itself, (attributes) and (signature)
+        SListFileCreateNodeForAllLocales(ha, LISTFILE_NAME);
+        SListFileCreateNodeForAllLocales(ha, SIGNATURE_NAME);
+        SListFileCreateNodeForAllLocales(ha, ATTRIBUTES_NAME);
+
+        // Move to the next archive in the chain
+        ha = ha->haPatch;
+    }
+    
     return dwErrCode;
 }
 

--- a/src/StormLib.h
+++ b/src/StormLib.h
@@ -1025,10 +1025,12 @@ bool   WINAPI SFileCloseArchive(HANDLE hMpq);
 // so you can use this API to combining more listfiles.
 // Note that this function is internally called by SFileFindFirstFile
 DWORD  WINAPI SFileAddListFile(HANDLE hMpq, const TCHAR * szListFile);
+DWORD  WINAPI SFileAddListFileEntries(HANDLE hMpq, const char ** listFileEntries, DWORD dwEntryCount);
 
 // Archive compacting
 bool   WINAPI SFileSetCompactCallback(HANDLE hMpq, SFILE_COMPACT_CALLBACK CompactCB, void * pvUserData);
 bool   WINAPI SFileCompactArchive(HANDLE hMpq, const TCHAR * szListFile, bool bReserved);
+bool   WINAPI SFileCompactWithList(HANDLE hMpq, const char ** listFileEntries, DWORD dwEntryCount);
 
 // Changing the maximum file count
 DWORD  WINAPI SFileGetMaxFileCount(HANDLE hMpq);
@@ -1111,6 +1113,12 @@ bool   WINAPI SFileSetFileLocale(HANDLE hFile, LCID lcNewLocale);
 bool   WINAPI SFileSetDataCompression(DWORD DataCompression);
 
 bool   WINAPI SFileSetAddFileCallback(HANDLE hMpq, SFILE_ADDFILE_CALLBACK AddFileCB, void * pvUserData);
+
+//-----------------------------------------------------------------------------
+// Support for adding files to the MPQ from memory
+bool   WINAPI SFileAddFileFromBufferEx(HANDLE hMpq, const char * szArchivedName, LPBYTE fileData, DWORD dwSize, DWORD dwFlags, DWORD dwCompression, DWORD dwCompressionNext);
+bool   WINAPI SFileAddFileFromBuffer(HANDLE hMpq, const char * szArchivedName, LPBYTE fileData, DWORD dwSize, DWORD dwFlags);
+bool   WINAPI SFileAddWaveFromBuffer(HANDLE hMpq, const char * szArchivedName, LPBYTE fileData, DWORD dwSize, DWORD dwFlags, DWORD dwQuality); 
 
 //-----------------------------------------------------------------------------
 // Compression and decompression


### PR DESCRIPTION
- Adds capability to add files & wavs to MPQs from memory
- Adds capability to add in-memory list files to MPQs/compact MPQs using in-memory listfiles

This is working code I'm using in my projects including StormLib, I've heard from a few other StarCraft tool creators that they would very much like to have these capabilities & are using older/buggier alternatives due to storm lib lacking the ability to write files into MPQs from memory.

With this pull request I'm more looking for a review than expecting a merge - to see if you're ok with adding such functions to StormLib in theory, thoughts on how to name the functions (e.g. like the other storm functions as I have it, or in a more separate fashion), and any other thoughts on the code/what's needed to add such capability to StormLib.