### PR TITLE
Add to listfile from memory

### DIFF
--- a/src/StormLib.h
+++ b/src/StormLib.h
@@ -1025,6 +1025,7 @@ bool   WINAPI SFileCloseArchive(HANDLE hMpq);
 // so you can use this API to combining more listfiles.
 // Note that this function is internally called by SFileFindFirstFile
 DWORD  WINAPI SFileAddListFile(HANDLE hMpq, const TCHAR * szListFile);
+DWORD  WINAPI SFileAddListFileEntries(HANDLE hMpq, const char ** listFileEntries, DWORD dwEntryCount);
 
 // Archive compacting
 bool   WINAPI SFileSetCompactCallback(HANDLE hMpq, SFILE_COMPACT_CALLBACK CompactCB, void * pvUserData);


### PR DESCRIPTION
Adds capability to add in-memory list file entries to MPQs.

For map editing tools it's convenient to not have to write new list file entries to disk prior to updating listfiles in MPQs.