### PR TITLE
Memory optimizations (Pkware)

### DIFF
--- a/src/SCompression.cpp
+++ b/src/SCompression.cpp
@@ -176,7 +176,7 @@ int Decompress_ZLIB(void * pvOutBuffer, int * pcbOutBuffer, void * pvInBuffer, i
         inflateEnd(&z);
     }
 
-	return (nResult >= Z_OK);
+    return (nResult >= Z_OK);
 }
 
 /******************************************************************************/
@@ -260,7 +260,7 @@ static void Compress_PKLIB(void * pvOutBuffer, int * pcbOutBuffer, void * pvInBu
         // Starcraft I uses the variable dictionary size based on algorithm below
         //
 
-        if (cbInBuffer < 0x600)
+        if(cbInBuffer < 0x600)
             dict_size = CMP_IMPLODE_DICT_SIZE1;
         else if(0x600 <= cbInBuffer && cbInBuffer < 0xC00)
             dict_size = CMP_IMPLODE_DICT_SIZE2;
@@ -278,26 +278,26 @@ static void Compress_PKLIB(void * pvOutBuffer, int * pcbOutBuffer, void * pvInBu
 static int Decompress_PKLIB(void * pvOutBuffer, int * pcbOutBuffer, void * pvInBuffer, int cbInBuffer)
 {
     TDataInfo Info;                             // Data information
-	char * work_buf;
-	int nResult = 0;
+    char * work_buf;
+    int nResult = 0;
 
     // Allocate Pklib's work buffer
     if((work_buf = STORM_ALLOC(char, EXP_BUFFER_SIZE)) != NULL)
-	{
-		// Fill data information structure
-		Info.pbInBuff     = (unsigned char *)pvInBuffer;
-		Info.pbInBuffEnd  = (unsigned char *)pvInBuffer + cbInBuffer;
-		Info.pbOutBuff    = (unsigned char *)pvOutBuffer;
-		Info.pbOutBuffEnd = (unsigned char *)pvOutBuffer + *pcbOutBuffer;
+    {
+        // Fill data information structure
+        Info.pbInBuff     = (unsigned char *)pvInBuffer;
+        Info.pbInBuffEnd  = (unsigned char *)pvInBuffer + cbInBuffer;
+        Info.pbOutBuff    = (unsigned char *)pvOutBuffer;
+        Info.pbOutBuffEnd = (unsigned char *)pvOutBuffer + *pcbOutBuffer;
 
-		// Do the decompression
-		if(explode(ReadInputData, WriteOutputData, work_buf, &Info) == CMP_NO_ERROR)
-			nResult = 1;
+        // Do the decompression
+        if(explode(ReadInputData, WriteOutputData, work_buf, &Info) == CMP_NO_ERROR)
+            nResult = 1;
 
-		// Give away the number of decompressed bytes
-		*pcbOutBuffer = (int)(Info.pbOutBuff - (unsigned char *)pvOutBuffer);
+        // Give away the number of decompressed bytes
+        *pcbOutBuffer = (int)(Info.pbOutBuff - (unsigned char *)pvOutBuffer);
         STORM_FREE(work_buf);
-	}
+    }
 
     return nResult;
 }
@@ -372,7 +372,7 @@ static int Decompress_BZIP2(void * pvOutBuffer, int * pcbOutBuffer, void * pvInB
         BZ2_bzDecompressEnd(&strm);
     }
 
-	return (nResult >= BZ_OK);
+    return (nResult >= BZ_OK);
 }
 
 /******************************************************************************/

--- a/src/SCompression.cpp
+++ b/src/SCompression.cpp
@@ -248,7 +248,6 @@ static void Compress_PKLIB(void * pvOutBuffer, int * pcbOutBuffer, void * pvInBu
     if(work_buf != NULL)
     {
         // Fill data information structure
-        memset(work_buf, 0, CMP_BUFFER_SIZE);
         Info.pbInBuff     = (unsigned char *)pvInBuffer;
         Info.pbInBuffEnd  = (unsigned char *)pvInBuffer + cbInBuffer;
         Info.pbOutBuff    = (unsigned char *)pvOutBuffer;
@@ -286,7 +285,6 @@ static int Decompress_PKLIB(void * pvOutBuffer, int * pcbOutBuffer, void * pvInB
     if((work_buf = STORM_ALLOC(char, EXP_BUFFER_SIZE)) != NULL)
 	{
 		// Fill data information structure
-		memset(work_buf, 0, EXP_BUFFER_SIZE);
 		Info.pbInBuff     = (unsigned char *)pvInBuffer;
 		Info.pbInBuffEnd  = (unsigned char *)pvInBuffer + cbInBuffer;
 		Info.pbOutBuff    = (unsigned char *)pvOutBuffer;

--- a/src/SFileAddFile.cpp
+++ b/src/SFileAddFile.cpp
@@ -148,7 +148,11 @@ static DWORD WriteDataToMpqFile(
         DWORD dwBytesInSector = hf->dwFilePos % hf->dwSectorSize;
         DWORD dwSectorIndex = hf->dwFilePos / hf->dwSectorSize;
         DWORD dwBytesToCopy;
-
+        // Allocate memory for SCompImplode (Compress_PKLIB)
+        if(pFileEntry->dwFlags & MPQ_FILE_IMPLODE)
+        {
+            InitializeSComp(true);
+        }
         // Process all data.
         while(dwDataSize != 0)
         {
@@ -270,6 +274,11 @@ static DWORD WriteDataToMpqFile(
                 dwBytesInSector = 0;
                 dwSectorIndex++;
             }
+        }
+        // Cleanup allocated memory of SCompImplode
+        if(pFileEntry->dwFlags & MPQ_FILE_IMPLODE)
+        {
+            UnInitializeSComp();
         }
     }
 

--- a/src/SFileReadFile.cpp
+++ b/src/SFileReadFile.cpp
@@ -102,6 +102,11 @@ static DWORD ReadMpqSectors(TMPQFile * hf, LPBYTE pbBuffer, DWORD dwByteOffset, 
     // Set file pointer and read all required sectors
     if(FileStream_Read(ha->pStream, &RawFilePos, pbInSector, dwRawBytesToRead))
     {
+        // Allocate memory for SCompExplode (Decompress_PKLIB) 
+        if(pFileEntry->dwFlags & MPQ_FILE_IMPLODE)
+        {
+            InitializeSComp(false);
+        }
         // Now we have to decrypt and decompress all file sectors that have been loaded
         for(DWORD i = 0; i < dwSectorsToRead; i++)
         {
@@ -213,6 +218,11 @@ static DWORD ReadMpqSectors(TMPQFile * hf, LPBYTE pbBuffer, DWORD dwByteOffset, 
             pbOutSector += dwBytesInThisSector;
             pbInSector += dwRawBytesInThisSector;
             dwSectorsDone++;
+        }
+        // Cleanup allocated memory of SCompExplode
+        if(pFileEntry->dwFlags & MPQ_FILE_IMPLODE)
+        {
+            UnInitializeSComp();
         }
     }
     else

--- a/src/StormCommon.h
+++ b/src/StormCommon.h
@@ -318,6 +318,8 @@ DWORD ConvertMpkHeaderToFormat4(TMPQArchive * ha, ULONGLONG FileSize, DWORD dwFl
 void DecryptMpkTable(void * pvMpkTable, size_t cbSize);
 TMPQHash * LoadMpkHashTable(TMPQArchive * ha);
 TMPQBlock * LoadMpkBlockTable(TMPQArchive * ha);
+void InitializeSComp(bool implode);
+void UnInitializeSComp();
 int SCompDecompressMpk(void * pvOutBuffer, int * pcbOutBuffer, void * pvInBuffer, int cbInBuffer);
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
1. do not clear the work-buffer before pkware explode/implode:
   - not necessary
2. pre-allocate memory of Compress_PKLIB/Decompress_PKLIB:
   - the size of the work-buffer is not insignificant (~35kb), while the sector is usually 4kb.
   - might want to compare PKLIB_work_buf to work_buf before STORM_FREE if thread-safety is a requirement...