### PR TITLE
Fixes #311 Access violation SFileGetileInfo and HashEntry

### DIFF
--- a/src/SFileGetFileInfo.cpp
+++ b/src/SFileGetFileInfo.cpp
@@ -72,6 +72,9 @@ static bool GetInfo(void * pvFileInfo, DWORD cbFileInfo, const void * pvData, DW
     if(!GetInfo_BufferCheck(pvFileInfo, cbFileInfo, cbData, pcbLengthNeeded))
         return false;
 
+    if (pvData == NULL)
+        return false;
+
     // Copy the data to the caller-supplied buffer
     memcpy(pvFileInfo, pvData, cbData);
     return true;
@@ -80,6 +83,9 @@ static bool GetInfo(void * pvFileInfo, DWORD cbFileInfo, const void * pvData, DW
 static bool GetInfo_Allocated(void * pvFileInfo, DWORD cbFileInfo, void * pvData, DWORD cbData, LPDWORD pcbLengthNeeded)
 {
     bool bResult;
+
+    if (pvData == NULL)
+        return false;
 
     // Verify buffer pointer and buffer size
     if((bResult = GetInfo_BufferCheck(pvFileInfo, cbFileInfo, cbData, pcbLengthNeeded)) != false)

--- a/src/SFileOpenFileEx.cpp
+++ b/src/SFileOpenFileEx.cpp
@@ -34,7 +34,7 @@ static DWORD FindHashIndex(TMPQArchive * ha, DWORD dwFileIndex)
         {
             // Duplicate hash entry found
             if(dwFirstIndex != HASH_ENTRY_FREE)
-                return HASH_ENTRY_FREE;
+                return dwFirstIndex;
             dwFirstIndex = (DWORD)(pHash - ha->pHashTable);
         }
     }


### PR DESCRIPTION
Access violation fixed by checking for null value on pvData in GetInfo before memcpy.
I made same fix to GetInfo_Allocated, assuming it could have the same issue, but didn't actually repro a bug or test if it fixed it.

Seems like also a possible bug in FindHashIndex. I would expect a valid hash name is available, since it's a real file (not sure since MPQ is corrupted).

I'm assuming the fake files are using duplicate hash indexes of the real files.
Seems like FindHashIndex incorrectly returns HASH_ENTRY_FREE instead of 1st found file when a duplicate is found?
Not sure I understand the algorithm correctly, or how this change would affect other unit test files.