### PR TITLE
Fix CompressADPCM argument order

### DIFF
--- a/src/adpcm/adpcm.h
+++ b/src/adpcm/adpcm.h
@@ -20,7 +20,7 @@
 //-----------------------------------------------------------------------------
 // Public functions
 
-int CompressADPCM       (void * pvOutBuffer, int dwOutLength, void * pvInBuffer, int dwInLength, int nCmpType, int ChannelCount);
+int CompressADPCM       (void * pvOutBuffer, int dwOutLength, void * pvInBuffer, int dwInLength, int ChannelCount, int nCmpType);
 int DecompressADPCM     (void * pvOutBuffer, int dwOutLength, void * pvInBuffer, int dwInLength, int ChannelCount);
 int DecompressADPCM_SC1B(void * pvOutBuffer, int cbOutBuffer, void * pvInBuffer, int cbInBuffer, int ChannelCount);
 


### PR DESCRIPTION
`ChannelCount` and `nCmpType` were the wrong way round.