### PR TITLE
Add STORM_UNICODE option for windows cmake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,17 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(CMakeDependentOption)
 include(GNUInstallDirs)
 
+option(STORM_UNICODE "Compile UNICODE version instead of ANSI one (Visual Studio only)" OFF)
+
+if(WIN32)
+    if(STORM_UNICODE)
+        message(STATUS "Build UNICODE version")
+        add_definitions(-DUNICODE -D_UNICODE)
+    else()
+        message(STATUS "Build ANSI version")
+    endif()
+endif()
+
 option(BUILD_SHARED_LIBS "Compile shared libraries" OFF)
 option(STORM_SKIP_INSTALL "Skip installing files" OFF)
 option(STORM_USE_BUNDLED_LIBRARIES


### PR DESCRIPTION
Presently when using cmake+vcpkg there doesn't seem to be a way to compile stormlib as unicode, this change adds the STORM_UNICODE option (which mirrors [CASC_UNICODE](https://github.com/ladislav-zezula/CascLib/blob/master/CMakeLists.txt#L78), making it possible to use a portfile to compile a unicode version of stormlib on windows.

This passed local testing (for opening/reading MPQ files using UTF16 filepaths) using a portfile.cmake with the following contents...
<details>
<summary>portfile.cmake</summary>

> 
> message("using vcpkg overlay port for stormlib")
> 
> vcpkg_from_github(
>     OUT_SOURCE_PATH SOURCE_PATH
>     REPO TheNitesWhoSay/StormLib
>     REF d65f31f21a3b5b4e2e3b5c17a68253126fdcaeee
>     SHA512 7288fc229299e1b3e171c30b4f125eca327c0f8b65695ac6aab1b039c15595d64c10c9786da743102654113e19281b21a96ddd69d4381019692ee53271203ed1
>     HEAD_REF master
> )
> 
> set(STORM_UNICODE ON)
> 
> vcpkg_cmake_configure(
>     SOURCE_PATH "${SOURCE_PATH}"
>     OPTIONS
>         -DSTORM_UNICODE=${STORM_UNICODE}
> )
> 
> vcpkg_cmake_install()
> vcpkg_cmake_config_fixup(PACKAGE_NAME StormLib)
> vcpkg_copy_pdbs()
> 
> 
> file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
> file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
> file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
> 

</details>