### PR TITLE
Win: Only define NOMINMAX if it's not already defined

### DIFF
--- a/src/StormPort.h
+++ b/src/StormPort.h
@@ -54,7 +54,9 @@
   #include <stdio.h>
 
   // Suppress definitions of `min` and `max` macros by <windows.h>:
+  #ifndef NOMINMAX
   #define NOMINMAX 1
+  #endif
   #include <windows.h>
   #include <wininet.h>
 


### PR DESCRIPTION
Makes it easier to add StormLib as a dependency