### PR TITLE
Use stdbool.h for bool definition

### DIFF
--- a/src/StormPort.h
+++ b/src/StormPort.h
@@ -28,7 +28,15 @@
 #define __STORMPORT_H__
 
 #ifndef __cplusplus
-  #include <stdbool.h>
+  #if defined(_MSC_VER) && _MSC_VER < 1800
+    /* Pre-VS2013 MSVC: no <stdbool.h> */
+    #define bool  char
+    #define true  1
+    #define false 0
+  #else
+    /* C99+ */
+    #include <stdbool.h>
+  #endif
 #endif
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
C99 which introduced stdbool.h has been around for 25+ years at this point, i see no need to support pre-C99 compilers. And it created annoying warnings in a project i'm working on:

```
$ bash build.sh 
configure: cmake -S /home/hans/projects/StormLib -B /home/hans/projects/StormLib/wasm/build -D BUILD_SHARED_LIBS=OFF -D STORM_USE_BUNDLED_LIBRARIES=ON -D STORM_SKIP_INSTALL=ON -D CMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=/usr/share/emscripten/cmake/Modules/Platform/Emscripten.cmake -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/node;--experimental-wasm-threads
-- Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR) 
-- Could NOT find BZip2 (missing: BZIP2_LIBRARIES BZIP2_INCLUDE_DIR) 
-- Linking against dependent libraries statically
-- Configuring done (1.6s)
-- Generating done (0.0s)
-- Build files have been written to: /home/hans/projects/StormLib/wasm/build
[100%] Built target storm
In file included from /home/hans/projects/StormLib/wasm/shim.c:3:
In file included from /home/hans/projects/StormLib/wasm/../src/StormLib.h:88:
/home/hans/projects/StormLib/src/StormPort.h:31:11: warning: 'bool' macro redefined [-Wmacro-redefined]
  #define bool char
          ^
/usr/lib/llvm-15/lib/clang/15.0.7/include/stdbool.h:20:9: note: previous definition is here
#define bool _Bool
        ^
1 warning generated.
```