### PR TITLE
silence -Wswitch-enum

### DIFF
--- a/src/SFileOpenArchive.cpp
+++ b/src/SFileOpenArchive.cpp
@@ -547,7 +547,10 @@ bool WINAPI SFileOpenArchive(
                 ha->dwValidFileFlags = MPQ_FILE_VALID_FLAGS_W3X;
                 ha->dwFlags |= MPQ_FLAG_WAR3_MAP;
                 break;
-            default:
+            case MapTypeNotChecked:
+            case MapTypeNotRecognized:
+            case MapTypeAviFile:
+            case MapTypeStarcraft2:
                 // silence -Wswitch-enum
                 break;
         }


### PR DESCRIPTION
compiling with clang, https://clang.llvm.org/docs/DiagnosticsReference.html#wswitch-enum

```
/home/hans/projects/StormLib/src/SFileOpenArchive.cpp:539:16: warning: 4 enumeration values not handled in switch: 'MapTypeNotChecked', 'MapTypeNotRecognized', 'MapTypeAviFile'... [-Wswitch]
        switch(MapType)
               ^~~~~~~
1 warning generated.
```

- does not appear to be an actual bug in the code, it's just code that looks suspicious like "this might be buggy" to a linter.