### PR TITLE
Add support for PKLIB compression hints

### DIFF
--- a/src/SCompression.cpp
+++ b/src/SCompression.cpp
@@ -238,10 +238,9 @@ static void Compress_PKLIB(void * pvOutBuffer, int * pcbOutBuffer, void * pvInBu
     TDataInfo Info;                                      // Data information
     char * work_buf = STORM_ALLOC(char, CMP_BUFFER_SIZE);// Pklib's work buffer
     unsigned int dict_size;                              // Dictionary size
-    unsigned int ctype = CMP_BINARY;                     // Compression type
+    unsigned int ctype = (pCmpType && *pCmpType == DATA_TYPE_TEXT) ? CMP_ASCII : CMP_BINARY; // Compression type
 
     // Keep compilers happy
-    STORMLIB_UNUSED(pCmpType);
     STORMLIB_UNUSED(nCmpLevel);
 
     // Handle no-memory condition


### PR DESCRIPTION
Adds support for Text/ASCII hint type passed through SCompCompress to PKLIB compression which matches Storm.dll behaviour.

When wrapping SComp to reimplement original SFile functionality, some test cases generated via Starcraft 1.17's Storm.dll were failing.

WIP test code: https://github.com/Starsurgical/squall/blob/scomp/test/Comp.cpp
Patch to pass tests: https://github.com/Starsurgical/squall/blob/scomp/vendor/stormlib-9.31/src/SCompression.cpp#L241-L244