### PR TITLE
Fix an ADPCM compression edge case

### DIFF
--- a/src/adpcm/adpcm.cpp
+++ b/src/adpcm/adpcm.cpp
@@ -188,6 +188,9 @@ int CompressADPCM(void * pvOutBuffer, int cbOutBuffer, void * pvInBuffer, int cb
     int MaxBitMask;
     int StepSize;
 
+    // Don't compress when buffer size is too small
+    if (2 * ChannelCount + 2 > cbOutBuffer) return 2 * ChannelCount + 2;
+
     // First byte in the output stream contains zero. The second one contains the compression level
     os.WriteByteSample(0);
     if(!os.WriteByteSample(BitShift))


### PR DESCRIPTION
Similar to #432 , this was another failed test by accident and is meant to match Storm.dll behaviour better.

Without the change, if SCompCompress was passed a sufficiently large dest buffer size it would be the same, but with a small dest buffer size it failed (it compressed the data when the dest buffer size was small and didn't when it was large). Happens on all ADPCM for all opts.

The short-circuit exists in Starcraft 1.17, WoW, and WC3.

Patch: https://github.com/Starsurgical/squall/blob/scomp/vendor/stormlib-9.31/src/adpcm/adpcm.cpp#L191-L194

### Without the change
Source input: `00 00 00 00`
Dest size: `4`
Result: 
```
SCompCompress
  normal operation
  smallest_null.bin
  compressed size too large
  ADPCM_Stereo_2_
-------------------------------------------------------------------------------
C:\Users\heine\squall\test\Comp.cpp(127)
...............................................................................

C:\Users\heine\squall\test\Comp.cpp(135): FAILED:
  CHECK( destsize == data.size() )
with expansion:
  3 == 4

C:\Users\heine\squall\test\Comp.cpp(136): FAILED:
  CHECK_THAT( dest, Catch::Matchers::Equals(expected) )
with expansion:
  { 'Ç', 0, 3 } Equals: { 0, 0, 0, 0 }
```

Source input: `00 00 00 00`
Dest size: `5`
Result: All passed.
