### PR TITLE
Fixing memory leak

### DIFF
--- a/src/SFileVerify.cpp
+++ b/src/SFileVerify.cpp
@@ -481,7 +481,10 @@ static DWORD VerifyStrongSignatureWithKey(
 
     // Verify the signature
     if(rsa_verify_simple(reversed_signature, MPQ_STRONG_SIGNATURE_SIZE, padded_digest, MPQ_STRONG_SIGNATURE_SIZE, &result, &key) != CRYPT_OK)
+    {
+        rsa_free(&key);
         return ERROR_VERIFY_FAILED;
+    }
 
     // Free the key and return result
     rsa_free(&key);


### PR DESCRIPTION
`VerifyStrongSignatureWithKey` (`src/SFileVerify.cpp`) leaks the imported `rsa_key` when `rsa_verify_simple` returns anything other than `CRYPT_OK`. The early-return path was missing the matching `rsa_free`.