### PR TITLE
Update the `.rc` and use it in CMake DLL build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,12 @@ if(BUILD_SHARED_LIBS)
         set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION "${VERSION_STRING}")
         set_target_properties(${LIBRARY_NAME} PROPERTIES SOVERSION "${VERSION_MAJOR}")
     endif()
+    if(WIN32)
+        target_sources(${LIBRARY_NAME}
+            PRIVATE
+                src/DllMain.rc
+        )
+    endif()
 else()
     message(STATUS "Linking against dependent libraries statically")
 endif()

--- a/src/DllMain.rc
+++ b/src/DllMain.rc
@@ -25,17 +25,16 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 9,26,0,3
- PRODUCTVERSION 9,26,0,3
- FILEFLAGSMASK 0x17L
+ FILEVERSION 9,40,0,0
+ PRODUCTVERSION 9,40,0,0
+ FILEFLAGSMASK VS_FF_DEBUG
 #ifdef _DEBUG
- FILEFLAGS 0x1L
+ FILEFLAGS VS_FF_DEBUG
 #else
  FILEFLAGS 0x0L
 #endif
- FILEOS 0x4L
- FILETYPE 0x0L
- FILESUBTYPE 0x0L
+ FILEOS VOS__WINDOWS32
+ FILETYPE VFT_DLL
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
@@ -43,12 +42,12 @@ BEGIN
         BEGIN
             VALUE "Comments", "http://www.zezula.net/mpq.html"
             VALUE "FileDescription", "StormLib library for reading Blizzard MPQ archives"
-            VALUE "FileVersion", "9.26.0.3"
+            VALUE "FileVersion", "9.40.0.0"
             VALUE "InternalName", "StormLib"
-            VALUE "LegalCopyright", "Copyright (c) 2014 - 2024 Ladislav Zezula"
+            VALUE "LegalCopyright", "Copyright (c) 2014 - 2026 Ladislav Zezula"
             VALUE "OriginalFilename", "StormLib.dll"
             VALUE "ProductName", "StormLib"
-            VALUE "ProductVersion", "9.26.0.3"
+            VALUE "ProductVersion", "9.40.0.0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
This attempts to address a discrepancy where the CMake build is producing a Windows shared library devoid of resources that are normally part of the VC project build.

I took the liberty and also updated version/copyright information in the `.rc` file while at it.

I am aware that similar bits are left neglected in the `CMakeLists.txt`, but given that version information should be ideally generated at build time, I won't be messing with any of that.

**EDIT**: Just to elaborate further, the reason behind this update is that as I am loading `StormLib` dynamically in a project, I would like to be able to tell which version I actually got my hands on. Since the library itself doesn't expose any routines that would return its precise version number, I decided to rely on PE resources instead. And since that's the case, why not make sure they're kept up-to-date and available in the first place?