### PR TITLE
Expose file MD5 through SFileGetFileInfo

### DIFF
--- a/src/SFileGetFileInfo.cpp
+++ b/src/SFileGetFileInfo.cpp
@@ -461,6 +461,10 @@ bool WINAPI SFileGetFileInfo(
 
         case SFileInfoCRC32:
             return GetInfo(pvFileInfo, cbFileInfo, &hf->pFileEntry->dwCrc32, sizeof(DWORD), pcbLengthNeeded);
+
+        case SFileInfoMD5:
+            return GetInfo(pvFileInfo, cbFileInfo, hf->pFileEntry->md5, MD5_DIGEST_SIZE, pcbLengthNeeded);
+
         default:
             // Invalid info class
             return GetInfo_ReturnError(ERROR_INVALID_PARAMETER);

--- a/src/StormLib.h
+++ b/src/StormLib.h
@@ -482,6 +482,7 @@ typedef enum _SFileInfoClass
     SFileInfoEncryptionKey,                 // File encryption key
     SFileInfoEncryptionKeyRaw,              // Unfixed value of the file key
     SFileInfoCRC32,                         // CRC32 of the file
+    SFileInfoMD5,                           // MD5 of the file, from (attributes). 0 if not present (BYTE [MD5_DIGEST_SIZE])
 
     SFileInfoInvalid = 0xFFF,               // Invalid file info class
 } SFileInfoClass;


### PR DESCRIPTION
This PR adds `SFileInfoMD5` to StormLib's file information classes.

This allows callers to retrieve the MD5 associated with a file in an MPQ's `(attributes)` file through the existing `SFileGetFileInfo` API, without requiring access to the internal `TFileEntry` structure.

StormLib already exposes the CRC32 stored in `(attributes)` through `SFileInfoCRC32`, but there is currently no equivalent way to retrieve the stored MD5.

Callers must otherwise request the complete `TFileEntry` structure and interpret its layout themselves. That is fragile because `TFileEntry` also contains an internal filename pointer and is not an ideal interface for retrieving one field.

If no MD5 is available in the attributes data, the returned buffer contains the existing zero-filled value from the file entry, consistent with StormLib's current representation.