### PR TITLE
Fix system libtomcrypt compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,6 +346,10 @@ if (NOT WITH_BUNDLED_LIBTOMCRYPT)
         message(STATUS "Found libtomcrypt via pkg-config")
         target_link_libraries(${LIBRARY_NAME} PRIVATE PkgConfig::libtomcrypt)
     endif()
+    # Use the system's own tomcrypt.h instead of the bundled (vendored) copy,
+    # since the two can disagree on struct layouts (e.g. ltc_math_descriptor)
+    # across libtomcrypt versions, which is ABI-incompatible with the system .so.
+    target_compile_definitions(${LIBRARY_NAME} PRIVATE __SYS_LIBTOMCRYPT)
 else()
     message(STATUS "Using bundled libtomcrypt sources")
     set(SRC_ADDITIONAL_FILES ${SRC_ADDITIONAL_FILES} ${TOMCRYPT_FILES})

--- a/src/StormCommon.h
+++ b/src/StormCommon.h
@@ -51,7 +51,46 @@
 // Cryptography support
 
 // Headers from LibTomCrypt
-#include "libtomcrypt/src/headers/tomcrypt.h"
+#ifndef __SYS_LIBTOMCRYPT
+  #include "libtomcrypt/src/headers/tomcrypt.h"
+#else
+  // StormLib always uses LibTomMath as its bignum backend (see
+  // InitializeMpqCryptography() in SBaseCommon.cpp), but some distro
+  // packages of LibTomCrypt ship a tomcrypt_custom.h with LTM_DESC
+  // disabled by default. The symbol is still exported by the library
+  // itself, so force the declaration on regardless of the packaged config.
+  #ifndef LTM_DESC
+    #define LTM_DESC
+  #endif
+  #include <tomcrypt.h>
+
+  // Compatibility layer for custom additions StormLib makes to its bundled
+  // fork of LibTomCrypt, which are not present in upstream/system headers.
+
+  // StormLib's bundled headers use this (differently-named) enum value
+  // instead of the upstream LTC_PKCS_1_V1_5; the underlying value is the same.
+  #ifndef LTC_LTC_PKCS_1_V1_5
+    #define LTC_LTC_PKCS_1_V1_5 LTC_PKCS_1_V1_5
+  #endif
+
+  // rsa_verify_simple() is a StormLib-specific addition (see
+  // src/libtomcrypt/src/pk/rsa/rsa_verify_simple.c) that is not part of
+  // upstream LibTomCrypt, so the system header does not declare it.
+  // It is implemented in a plain .c file (C linkage), so the declaration
+  // needs to be wrapped in extern "C" when seen from C++ translation units.
+  #ifdef LTC_MRSA
+    #ifdef __cplusplus
+extern "C" {
+    #endif
+int rsa_verify_simple(const unsigned char *sig,  unsigned long siglen,
+                      const unsigned char *hash, unsigned long hashlen,
+                            int           *stat,
+                            rsa_key       *key);
+    #ifdef __cplusplus
+}
+    #endif
+  #endif
+#endif
 
 // For HashStringJenkins
 #include "jenkins/lookup.h"

--- a/src/libtomcrypt/src/pk/rsa/rsa_verify_simple.c
+++ b/src/libtomcrypt/src/pk/rsa/rsa_verify_simple.c
@@ -8,7 +8,27 @@
  *
  * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
  */
-#include "../../headers/tomcrypt.h"
+
+// This file is always compiled, regardless of whether StormLib uses its
+// bundled LibTomCrypt or the system's. When linking against the system
+// library, the struct layout of ltc_math_descriptor (used indirectly via
+// the global ltc_mp) must match the system's, or accessing its members
+// (e.g. ltc_mp.rsa_me below) is undefined behavior. So mirror the same
+// header selection used by StormCommon.h instead of always including the
+// bundled header.
+#ifndef __SYS_LIBTOMCRYPT
+  #include "../../headers/tomcrypt.h"
+#else
+  #ifndef LTM_DESC
+    #define LTM_DESC
+  #endif
+  // This file uses the internal mp_* helper macros (e.g. mp_count_bits),
+  // which system packages only expose when LTC_SOURCE is defined.
+  #ifndef LTC_SOURCE
+    #define LTC_SOURCE
+  #endif
+  #include <tomcrypt.h>
+#endif
 
 /**
   @file rsa_verify_simple.c


### PR DESCRIPTION
Fix StormLib builds and RSA signature verification when using a system-provided LibTomCrypt instead of the bundled copy.

## Problem

StormLib previously linked against the system libtomcrypt library while including its bundled LibTomCrypt headers in several places. The bundled and system headers can define `ltc_math_descriptor` differently, resulting in an ABI mismatch when StormLib accesses the descriptor exported by the system library.

This could cause compilation failures or crashes during weak and strong RSA signature operations.

The system headers also differ from StormLib's bundled headers in a few compatibility details:

- The system package may not enable the LTM_DESC declaration by default.
 - The PKCS # 1 v1.5 constant is named `LTC_PKCS_1_V1_5` instead of `LTC_LTC_PKCS_1_V1_5`.
 - `rsa_verify_simple()` is a StormLib-specific helper and is not declared by upstream LibTomCrypt headers.

## Changes

- Define `__SYS_LIBTOMCRYPT` when StormLib links against a system LibTomCrypt.
- Include the system `<tomcrypt.h>` consistently in StormLib and `rsa_verify_simple.c`.
- Enable the `LTM_DESC` declaration when using system headers.
- Add a compatibility alias for `LTC_LTC_PKCS_1_V1_5`.
- Declare the StormLib-specific `rsa_verify_simple()` helper when using system headers.
- Preserve C linkage for the helper declaration.
- Define `LTC_SOURCE` where needed so internal LibTomCrypt math helper macros are available.

## Validation

Tested with the system packages:

- libtomcrypt-dev 1.18.2
- libtommath-dev 1.2.1