### PR TITLE
Move *BSD handling bits from CMake to StormPort.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,19 +359,6 @@ if(WIN32)
     target_link_libraries(${LIBRARY_NAME} PRIVATE wininet)
 endif()
 
-if(CMAKE_SYSTEM_NAME MATCHES "(Free|Net|Open)BSD")
-    message(STATUS "Using BSD port")
-    target_compile_definitions(${LIBRARY_NAME} PRIVATE
-        O_LARGEFILE=0
-        stat64=stat
-        lstat64=lstat
-        lseek64=lseek
-        off64_t=off_t
-        fstat64=fstat
-        ftruncate64=ftruncate
-    )
-endif()
-
 target_sources(${LIBRARY_NAME} PRIVATE ${SRC_FILES} ${SRC_ADDITIONAL_FILES} ${STORM_DEF_FILES})
 if(WIN32)
     set_target_properties(${LIBRARY_NAME} PROPERTIES OUTPUT_NAME "StormLib")

--- a/src/StormPort.h
+++ b/src/StormPort.h
@@ -378,8 +378,8 @@
 
 #endif // !STORMLIB_WINDOWS
 
-// 64-bit calls are supplied by "normal" calls on Mac
-#if defined(STORMLIB_MAC)
+// 64-bit calls are supplied by "normal" calls on *BSD and derivatives
+#if defined(STORMLIB_MAC) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
   #define stat64  stat
   #define fstat64 fstat
   #define lseek64 lseek


### PR DESCRIPTION
Get rid of the CMake bits for *BSD handling and use the proper StormPort.h
header bits that were already there. Also add DragonFly.